### PR TITLE
add support for specific enclosures and peerLinks

### DIFF
--- a/src/feed.js
+++ b/src/feed.js
@@ -492,10 +492,38 @@ class Feed {
           })
         }
 
+        if (isItem && el.enclosures) {
+          target.push({
+            enclosure: el.enclosures.map(({ length, type, url }) => ({
+              _attr: {
+                length,
+                type,
+                url
+              }
+            }))
+          })
+        }
+
         /**
          * Feed supports *one* MRSS media:group
          */
         let mediagroup = []
+
+        if (isItem && el.peerLinks) {
+          rss[0]._attr["xmlns:media"] = "http://search.yahoo.com/mrss/"
+
+          el.peerLinks.forEach(({ href, type }, index) =>
+            mediagroup.push({
+              "media:peerLink": [{
+                _attr: {
+                  href,
+                  isDefault: index === 0,
+                  type
+                }
+              }]
+            })
+          );
+        }
 
         /**
          * rss feed only supports 1 enclosure per el, so switching to
@@ -595,7 +623,7 @@ class Feed {
           })
         }
 
-        if (mediagroup.length > 1) {
+        if (mediagroup.length > 0) {
           /* make redundant information for MRSS clients that only look for the media:group and its contents */
           // mrss(entry, mediagroup, isItem = false) // isItem MUST be false, to prevent infinite recursion
 

--- a/src/feed.spec.js
+++ b/src/feed.spec.js
@@ -376,3 +376,40 @@ test('it should generate a Media RSS 1.5 feed', () => {
 
   expect(actual).toBe(expected)
 });
+
+test('it should generate a Media RSS 1.5 feed with specified enclosure tag', () => {
+  const length = 2423;
+  const type = 'video/mp4';
+  const url = 'https://enclosure.url/vid.mp4';
+
+  feed.addItem({
+    enclosures: [{
+      length,
+      type,
+      url
+    }]
+  });
+
+  expect(feed.rss2()).toContain(`<enclosure length="${length}" type="${type}" url="${url}"`);
+});
+
+test('it should generate a Media RSS 1.5 feed with specified peerLinks tag', () => {
+  const peerLinks = [
+    {
+      type: 'application/x-bittorent',
+      href: 'torrent.url'
+    },
+    {
+      type: 'application/x-bittorent2',
+      href: 'torrent.url2'
+    }
+  ];
+
+  feed.addItem({
+    peerLinks
+  });
+
+  peerLinks.forEach(({ href, type }, index) =>
+    expect(feed.rss2()).toContain(`<media:peerLink href="${href}" isDefault="${index === 0}" type="${type}"`)
+  );
+});


### PR DESCRIPTION
Adds support for settings specific enclosure and peerLink tags in an item. (I couldn't find out a solution based on our previous discussion (https://github.com/Chocobozzz/PeerTube/issues/4052#issuecomment-1017542291).)